### PR TITLE
Flatten assets directory, add custom checkbox, clean up some files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "laravel/framework": "^5.5"
+        "laravel/framework": "^5.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "laravel/framework": "^5.7"
+        "laravel/framework": "^5.5"
     },
     "autoload": {
         "psr-4": {

--- a/preview.md
+++ b/preview.md
@@ -1,5 +1,5 @@
-![Welcome Page](https://user-images.githubusercontent.com/7189795/40496997-244892aa-5f49-11e8-858f-65d970ba446b.png)
+![preview of welcome.blade.php](https://user-images.githubusercontent.com/7189795/43691209-15b4d88e-98e7-11e8-8621-97ee8682fbaa.png)
 
-![Login Page](https://user-images.githubusercontent.com/7189795/40496998-24658388-5f49-11e8-96b3-e55876e354a6.png)
+![preview of login.blade.php](https://user-images.githubusercontent.com/7189795/43691210-15c172a6-98e7-11e8-93b4-dd608439aef5.png)
 
-![Dashboard](https://user-images.githubusercontent.com/7189795/40496999-24827a74-5f49-11e8-8d8c-b7b6996f4539.png)
+![preview of home.blade.php](https://user-images.githubusercontent.com/7189795/43691211-15cb26fc-98e7-11e8-94b5-e2c823a59eee.png)

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ This is a Laravel front-end preset for Tailwind CSS. This preset will replace th
 
 ### Installation
 
-> **Warning**: Installing presets will **overwrite** your existing views and assets. Presets should be installed on a fresh installation of Laravel. Please use with caution.
+> **Warning**: Installing this preset will **overwrite** your existing views and assets, and should only be installed on a fresh installation of Laravel. Please use with caution.
 
 To install this preset, you must first require the composer dependency. Laravel will automatically register the service provider for you.
 

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ This is a Laravel front-end preset for Tailwind CSS. This preset will replace th
 
 ### Installation
 
-> **Warning**: Installing presets will affect your existing views and assets. Presets should be installed on a fresh installation of Laravel. Please use with caution.
+> **Warning**: Installing presets will **overwrite** your existing views and assets. Presets should be installed on a fresh installation of Laravel. Please use with caution.
 
 To install this preset, you must first require the composer dependency. Laravel will automatically register the service provider for you.
 

--- a/readme.md
+++ b/readme.md
@@ -28,16 +28,18 @@ php artisan preset tailwind
 php artisan preset tailwind-auth
 ```
 
+> **Note:** If you install the `tailwind-auth` preset on a version of Laravel that is older than 5.7, you may delete the `views/auth/verify.blade.php` file, as it will not be used.
+
 Install the NPM packages using your favorite package manager.
 
 ```
-yarn
+yarn // npm install
 ```
 
 Now you can compile the assets using any of the Laravel build scripts (dev, prod, watch).
 
 ```
-yarn dev
+yarn dev // npm run dev
 ```
 
 Ensure that your database is properly configured and migrated, and you're done! At this point, you may remove the composer dependency, as it is no longer needed.

--- a/readme.md
+++ b/readme.md
@@ -4,21 +4,21 @@
 [![Total Downloads](https://poser.pugx.org/zaknesler/tailwind-preset/downloads)](https://packagist.org/packages/zaknesler/tailwind-preset)
 [![License](https://poser.pugx.org/zaknesler/tailwind-preset/license)](https://packagist.org/packages/zaknesler/tailwind-preset)
 
-This preset will replace the default Bootstrap scaffolding with a custom Tailwind CSS preset. This preset includes the Vue JavaScript framework, and is compiled using Laravel Mix and PurgeCSS.
+This is a Laravel front-end preset for Tailwind CSS. This preset will replace the default Bootstrap scaffolding, including the example Vue.js component. It will also compile the assets using Laravel Mix and PurgeCSS in order to generate the smallest files possible.
 
 [**Demo**](https://preset.zaknesler.com) &middot; [View Screenshots](preview.md)
 
 ### Installation
 
-> **Warning**: Installing presets will affect your existing views and assets. Presets should be installed on a fresh installation of Laravel.
+> **Warning**: Installing presets will affect your existing views and assets. Presets should be installed on a fresh installation of Laravel. Please use with caution.
 
-To install, you must first add it as a composer dependency. Laravel will automatically register the service provider for you.
+To install this preset, you must first require the composer dependency. Laravel will automatically register the service provider for you.
 
 ```
 composer require zaknesler/tailwind-preset
 ```
 
-Next, install either the `tailwind` preset or the `tailwind-auth` preset. The `tailwind-auth` preset includes authentication views, routes, and a controller.
+Next, install either the `tailwind` or the `tailwind-auth` preset. The `tailwind-auth` preset includes authentication views, routes, and a controller.
 
 ```
 php artisan preset tailwind
@@ -31,16 +31,16 @@ php artisan preset tailwind-auth
 Install the NPM packages using your favorite package manager.
 
 ```
-yarn install
+yarn
 ```
 
-Now just compile the assets using any of the Laravel build scripts (dev, prod, watch).
+Now you can compile the assets using any of the Laravel build scripts (dev, prod, watch).
 
 ```
-yarn run dev
+yarn dev
 ```
 
-Make sure your database is configured and migrated, and you're done. At this point, you are free to remove the composer dependency, as it is no longer needed.
+Ensure that your database is properly configured and migrated, and you're done! At this point, you may remove the composer dependency, as it is no longer needed.
 
 ```
 composer remove zaknesler/tailwind-preset

--- a/src/Tailwind.php
+++ b/src/Tailwind.php
@@ -53,6 +53,18 @@ class Tailwind extends Preset
     }
 
     /**
+     * Ensure the component directories we need exist.
+     *
+     * @return void
+     */
+    protected static function ensureComponentDirectoryExists()
+    {
+        if (! File::isDirectory($directory = resource_path('js/components'))) {
+            File::makeDirectory($directory, 0755, true);
+        }
+    }
+
+    /**
      * Install authentication routes if they are not present.
      *
      * @return void
@@ -113,8 +125,8 @@ class Tailwind extends Preset
     {
         copy(__DIR__.'/stubs/webpack.stub', base_path('webpack.mix.js'));
 
-        copy(__DIR__.'/stubs/js/app.stub', resource_path('assets/js/app.js'));
-        copy(__DIR__.'/stubs/js/bootstrap.stub', resource_path('assets/js/bootstrap.js'));
+        copy(__DIR__.'/stubs/js/app.stub', resource_path('js/app.js'));
+        copy(__DIR__.'/stubs/js/bootstrap.stub', resource_path('js/bootstrap.js'));
 
         copy(__DIR__.'/stubs/tailwind.stub', base_path('tailwind.js'));
     }
@@ -126,13 +138,13 @@ class Tailwind extends Preset
      */
     protected static function installStyles()
     {
-        File::deleteDirectory(resource_path('assets/sass'));
+        File::deleteDirectory(resource_path('sass'));
 
-        if (! file_exists(resource_path('assets/less'))) {
-            File::makeDirectory(resource_path('assets/less'), 0777, true);
+        if (! file_exists(resource_path('less'))) {
+            File::makeDirectory(resource_path('less'), 0777, true);
         }
 
-        copy(__DIR__.'/stubs/less/app.stub', resource_path('assets/less/app.less'));
+        copy(__DIR__.'/stubs/less/app.stub', resource_path('less/app.less'));
     }
 
     /**
@@ -142,11 +154,11 @@ class Tailwind extends Preset
      */
     protected static function updateExampleComponent()
     {
-        File::cleanDirectory(resource_path('assets/js/components'));
+        File::cleanDirectory(resource_path('js/components'));
 
         copy(
             __DIR__.'/stubs/js/components/ExampleComponent.stub',
-            resource_path('assets/js/components/ExampleComponent.vue')
+            resource_path('js/components/ExampleComponent.vue')
         );
     }
 }

--- a/src/Tailwind.php
+++ b/src/Tailwind.php
@@ -16,6 +16,7 @@ class Tailwind extends Preset
     private static function setup()
     {
         static::ensureComponentDirectoryExists();
+        static::ensureResourceDirectoriesExist();
         static::updatePackages();
 
         static::installScripts();
@@ -105,6 +106,26 @@ class Tailwind extends Preset
     }
 
     /**
+     * Create any directories that do not exist.
+     *
+     * @return void
+     */
+    protected static function ensureResourceDirectoriesExist()
+    {
+        if (! file_exists(resource_path('less'))) {
+            File::makeDirectory(resource_path('less'), 0755, true);
+        }
+
+        if (! file_exists(resource_path('js'))) {
+            File::makeDirectory(resource_path('js'), 0755, true);
+        }
+
+        if (! file_exists(resource_path('js/components'))) {
+            File::makeDirectory(resource_path('js/components'), 0755, true);
+        }
+    }
+
+    /**
      * Install all JavaScript files.
      *
      * @return void
@@ -127,10 +148,6 @@ class Tailwind extends Preset
     {
         File::deleteDirectory(resource_path('sass'));
 
-        if (! file_exists(resource_path('less'))) {
-            File::makeDirectory(resource_path('less'), 0777, true);
-        }
-
         copy(__DIR__.'/stubs/less/app.stub', resource_path('less/app.less'));
     }
 
@@ -141,8 +158,6 @@ class Tailwind extends Preset
      */
     protected static function updateExampleComponent()
     {
-        File::cleanDirectory(resource_path('js/components'));
-
         copy(
             __DIR__.'/stubs/js/components/ExampleComponent.stub',
             resource_path('js/components/ExampleComponent.vue')

--- a/src/Tailwind.php
+++ b/src/Tailwind.php
@@ -15,7 +15,6 @@ class Tailwind extends Preset
      */
     private static function setup()
     {
-        static::ensureComponentDirectoryExists();
         static::ensureResourceDirectoriesExist();
         static::updatePackages();
 

--- a/src/Tailwind.php
+++ b/src/Tailwind.php
@@ -53,18 +53,6 @@ class Tailwind extends Preset
     }
 
     /**
-     * Ensure the component directories we need exist.
-     *
-     * @return void
-     */
-    protected static function ensureComponentDirectoryExists()
-    {
-        if (! File::isDirectory($directory = resource_path('js/components'))) {
-            File::makeDirectory($directory, 0755, true);
-        }
-    }
-
-    /**
      * Install authentication routes if they are not present.
      *
      * @return void

--- a/src/Tailwind.php
+++ b/src/Tailwind.php
@@ -83,7 +83,7 @@ class Tailwind extends Preset
             'cross-env' => '^5.2',
             'laravel-mix' => '^2.1',
             'laravel-mix-purgecss' => '^2.2',
-            'less' => '^3.0',
+            'less' => '^3.8',
             'less-loader' => '^4.1',
             'tailwindcss' => '^0.6',
             'vue' => '^2.5',

--- a/src/Tailwind.php
+++ b/src/Tailwind.php
@@ -111,12 +111,11 @@ class Tailwind extends Preset
      */
     protected static function installScripts()
     {
+        copy(__DIR__.'/stubs/tailwind.stub', base_path('tailwind.js'));
         copy(__DIR__.'/stubs/webpack.stub', base_path('webpack.mix.js'));
 
         copy(__DIR__.'/stubs/js/app.stub', resource_path('js/app.js'));
         copy(__DIR__.'/stubs/js/bootstrap.stub', resource_path('js/bootstrap.js'));
-
-        copy(__DIR__.'/stubs/tailwind.stub', base_path('tailwind.js'));
     }
 
     /**

--- a/src/TailwindServiceProvider.php
+++ b/src/TailwindServiceProvider.php
@@ -36,6 +36,6 @@ class TailwindServiceProvider extends ServiceProvider
     protected function installMessage($command)
     {
         $command->info('Tailwind scaffolding installed successfully.');
-        $command->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
+        $command->comment('Please run "yarn && yarn dev" to compile your fresh scaffolding.');
     }
 }

--- a/src/stubs/js/app.stub
+++ b/src/stubs/js/app.stub
@@ -1,8 +1,8 @@
-import './bootstrap';
+import './bootstrap'
 
-import ExampleComponent from './components/ExampleComponent.vue';
+import ExampleComponent from './components/ExampleComponent.vue'
 
-Vue.component('example-component', ExampleComponent);
+Vue.component('example-component', ExampleComponent)
 
 const app = new Vue({
     el: '#app',
@@ -13,7 +13,7 @@ const app = new Vue({
 
     methods: {
         logout() {
-            this.$refs.logoutForm.submit();
+            this.$refs.logoutForm.submit()
         }
     }
-});
+})

--- a/src/stubs/js/bootstrap.stub
+++ b/src/stubs/js/bootstrap.stub
@@ -1,10 +1,10 @@
-import Vue from 'vue';
-import axios from 'axios';
+import Vue from 'vue'
+import axios from 'axios'
 
-window.Vue = Vue;
-window.axios = axios;
+window.Vue = Vue
+window.axios = axios
 
 axios.defaults.headers.common = {
     'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]').content,
     'X-Requested-With': 'XMLHttpRequest'
-};
+}

--- a/src/stubs/js/bootstrap.stub
+++ b/src/stubs/js/bootstrap.stub
@@ -4,7 +4,7 @@ import axios from 'axios'
 window.Vue = Vue
 window.axios = axios
 
-axios.defaults.headers.common = {
-    'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]').content,
+window.axios.defaults.headers.common = {
+    'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]').getAttribute('content'),
     'X-Requested-With': 'XMLHttpRequest'
 }

--- a/src/stubs/less/app.stub
+++ b/src/stubs/less/app.stub
@@ -2,10 +2,34 @@
 @tailwind components;
 
 
+input[type=checkbox] {
+    @apply .relative .border .bg-grey-lighter .rounded-sm .outline-none .appearance-none .cursor-pointer .overflow-hidden .w-4 .h-4;
 
+    transition: background 100ms ease-in-out;
 
+    &:focus,
+    &:active,
+    &:checked {
+        @apply .border-blue;
+    }
 
+    &::after {
+        @apply .block .absolute .opacity-0;
 
-[v-cloak] {
-    @apply .hidden;
+        content: '';
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='white' viewBox='0 0 20 20'%3E%3Cpath d='M0 11l2-2 5 5L18 3l2 2L7 18z'/%3E%3C/svg%3E");
+        width: calc(100% - 4px);
+        height: calc(100% - 4px);
+        top: 2px;
+        left: 2px;
+        transition: opacity 100ms ease-in-out;
+    }
+
+    &:checked {
+        @apply .bg-blue;
+
+        &::after {
+            @apply .opacity-100;
+        }
+    }
 }

--- a/src/stubs/less/app.stub
+++ b/src/stubs/less/app.stub
@@ -1,6 +1,10 @@
 @tailwind preflight;
 @tailwind components;
+@tailwind utilities;
 
+[v-cloak] {
+    @apply .hidden;
+}
 
 input[type=checkbox] {
     @apply .relative .border .bg-grey-lighter .rounded-sm .outline-none .appearance-none .cursor-pointer .overflow-hidden .w-4 .h-4;

--- a/src/stubs/less/app.stub
+++ b/src/stubs/less/app.stub
@@ -1,65 +1,8 @@
-/**
- * This injects Tailwind's base styles, which is a combination of
- * Normalize.css and some additional base styles.
- *
- * You can see the styles here:
- * https://github.com/tailwindcss/tailwindcss/blob/master/css/preflight.css
- *
- * If using `postcss-import`, use this import instead:
- *
- * @import "tailwindcss/preflight";
- */
 @tailwind preflight;
-
-/**
- * This injects any component classes registered by plugins.
- *
- * If using `postcss-import`, use this import instead:
- *
- * @import "tailwindcss/components";
- */
 @tailwind components;
 
-/**
- * Here you would add any of your custom component classes; stuff that you'd
- * want loaded *before* the utilities so that the utilities could still
- * override them.
- *
- * Example:
- *
- * .btn { ... }
- * .form-input { ... }
- *
- * Or if using a preprocessor or `postcss-import`:
- *
- * @import "components/buttons";
- * @import "components/forms";
- */
 
-/**
- * This injects all of Tailwind's utility classes, generated based on your
- * config file.
- *
- * If using `postcss-import`, use this import instead:
- *
- * @import "tailwindcss/utilities";
- */
-@tailwind utilities;
 
-/**
- * Here you would add any custom utilities you need that don't come out of the
- * box with Tailwind.
- *
- * Example:
- *
- * .bg-pattern-graph-paper { ... }
- * .skew-45 { ... }
- *
- * Or if using a preprocessor or `postcss-import`:
- *
- * @import "utilities/background-patterns";
- * @import "utilities/skew-transforms";
- */
 
 
 

--- a/src/stubs/less/app.stub
+++ b/src/stubs/less/app.stub
@@ -61,13 +61,7 @@
  * @import "utilities/skew-transforms";
  */
 
-html {
-    @apply .h-full;
-}
 
-body {
-    @apply .min-h-full .h-full;
-}
 
 [v-cloak] {
     @apply .hidden;

--- a/src/stubs/tailwind.stub
+++ b/src/stubs/tailwind.stub
@@ -897,6 +897,7 @@ module.exports = {
     shadows: ['responsive', 'hover', 'focus'],
     svgFill: [],
     svgStroke: [],
+    tableLayout: ['responsive'],
     textAlign: ['responsive'],
     textColors: ['responsive', 'hover', 'focus'],
     textSizes: ['responsive'],
@@ -926,10 +927,10 @@ module.exports = {
   */
 
   plugins: [
-    // require('./plugins/container')({
-    //   // center: true,
-    //   // padding: '1rem',
-    // }),
+    require('tailwindcss/plugins/container')({
+      // center: true,
+      // padding: '1rem',
+    }),
   ],
 
 

--- a/src/stubs/views/auth/auth/login.blade.php
+++ b/src/stubs/views/auth/auth/login.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts/base')
 
-@section('title', 'Login')
+@section('title', 'Sign in')
 
 @section('show-header', false)
 
@@ -57,7 +57,7 @@
                         </div>
 
                         <div class="block mb-8">
-                            <input class="appearance-none w-full border-0 bg-blue hover:bg-blue-dark text-white rounded cursor-pointer p-3" type="submit" value="Login" />
+                            <input class="appearance-none w-full border-0 bg-blue hover:bg-blue-dark text-white rounded cursor-pointer p-3" type="submit" value="Sign in" />
                         </div>
 
                         <div class="text-center text-sm text-grey-dark">

--- a/src/stubs/views/auth/auth/login.blade.php
+++ b/src/stubs/views/auth/auth/login.blade.php
@@ -61,7 +61,7 @@
                         </div>
 
                         <div class="text-center text-sm text-grey-dark">
-                            Don't have an account? <a class="font-semibold text-grey-darker no-underline hover:underline" href="{{ route('register') }}">Sign up</a>.
+                            Don't have an account? <a class="font-semibold text-grey-darker no-underline hover:underline" href="{{ route('register') }}">Sign up</a>
                         </div>
                     </form>
                 </div>

--- a/src/stubs/views/auth/auth/passwords/email.blade.php
+++ b/src/stubs/views/auth/auth/passwords/email.blade.php
@@ -45,7 +45,7 @@
                         </div>
 
                         <div class="text-center text-sm text-grey-dark">
-                            Remember it? <a class="font-semibold text-grey-darker no-underline hover:underline" href="{{ route('login') }}">Sign in</a>.
+                            Remember it? <a class="font-semibold text-grey-darker no-underline hover:underline" href="{{ route('login') }}">Sign in</a>
                         </div>
                     </form>
                 </div>

--- a/src/stubs/views/auth/auth/register.blade.php
+++ b/src/stubs/views/auth/auth/register.blade.php
@@ -81,7 +81,7 @@
                         </div>
 
                         <div class="text-center text-sm text-grey-dark">
-                            Have an account? <a class="font-semibold text-grey-darker no-underline hover:underline" href="{{ route('login') }}">Sign in</a>.
+                            Have an account? <a class="font-semibold text-grey-darker no-underline hover:underline" href="{{ route('login') }}">Sign in</a>
                         </div>
                     </form>
                 </div>

--- a/src/stubs/views/auth/auth/register.blade.php
+++ b/src/stubs/views/auth/auth/register.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts/base')
 
-@section('title', 'Register')
+@section('title', 'Sign up')
 
 @section('show-header', false)
 
@@ -77,7 +77,7 @@
                         </div>
 
                         <div class="block mb-8">
-                            <input class="appearance-none w-full border-0 bg-blue hover:bg-blue-dark text-white rounded cursor-pointer p-3" type="submit" value="Register" />
+                            <input class="appearance-none w-full border-0 bg-blue hover:bg-blue-dark text-white rounded cursor-pointer p-3" type="submit" value="Sign up" />
                         </div>
 
                         <div class="text-center text-sm text-grey-dark">

--- a/src/stubs/views/auth/auth/verify.blade.php
+++ b/src/stubs/views/auth/auth/verify.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts/base')
+
+@section('title', 'Sign in')
+
+@section('show-header', false)
+
+@section('content-full')
+    <div class="min-h-full h-full bg-grey-lightest flex flex-col items-center overflow-auto">
+        <div class="m-auto max-w-sm w-full sm:px-8">
+            <div class="m-8">
+                <div class="text-xl text-center mb-8">
+                    <a class="text-grey-darker hover:text-grey-darkest no-underline" href="/">{{ config('app.name') }}</a>
+                </div>
+
+                <div class="bg-white rounded">
+                    <div class="block rounded-t w-full h-2 bg-blue"></div>
+
+                    <div class="w-full border border-t-0 rounded-b p-8">
+                        <div class="text-lg text-grey-darkest text-center mb-8">Verify your email</div>
+
+                        <div class="text-center mb-8">
+                            @if (session('resent'))
+                                <p>A fresh verification link has been sent to your email.</p>
+                            @else
+                                <p>Please check your email for the verification link.</p>
+                            @endif
+                        </div>
+
+                        <div class="text-center text-sm text-grey-dark">
+                            Didn't get the email? <a class="font-semibold text-blue-dark no-underline hover:underline" href="{{ route('verification.resend') }}">Resend</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/src/stubs/views/auth/errors/503.blade.php
+++ b/src/stubs/views/auth/errors/503.blade.php
@@ -10,6 +10,6 @@
 
         <div class="block w-16 h-1 bg-blue my-6"></div>
 
-        <div class="text-lg text-grey-dark">We'll be right back.</div>
+        <div class="text-lg text-grey-dark">{{ $exception->getMessage() ?: 'We\'ll be right back.' }}</div>
     </div>
 @endsection

--- a/src/stubs/views/auth/layouts/base.blade.php
+++ b/src/stubs/views/auth/layouts/base.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ app()->getLocale() }}" class="h-full">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-full">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/stubs/views/auth/layouts/base.blade.php
+++ b/src/stubs/views/auth/layouts/base.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ app()->getLocale() }}">
+<html lang="{{ app()->getLocale() }}" class="h-full">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -11,7 +11,7 @@
         <link href="{{ mix('css/app.css') }}" rel="stylesheet">
         <script src="{{ mix('js/app.js') }}" defer></script>
     </head>
-    <body class="font-sans font-normal roman text-base tracking-normal leading-normal bg-white text-grey-darker antialiased">
+    <body class="font-sans font-normal roman text-base tracking-normal leading-normal bg-white text-grey-darker antialiased min-h-full h-full">
         <div id="app" class="min-h-full h-full" v-cloak>
             @hasSection('show-header')
                 @include('layouts/partials/_header')

--- a/src/stubs/views/auth/layouts/base.blade.php
+++ b/src/stubs/views/auth/layouts/base.blade.php
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
     <head>
-        <meta charset="utf-8" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" />
-        <meta name="csrf-token" content="{{ csrf_token() }}" />
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title>@hasSection('title') @yield('title') &dash; {{ config('app.name') }} @else {{ config('app.name') }} @endif</title>
 
-        <link href="{{ mix('css/app.css') }}" rel="stylesheet" />
+        <link href="{{ mix('css/app.css') }}" rel="stylesheet">
         <script src="{{ mix('js/app.js') }}" defer></script>
     </head>
     <body class="font-sans font-normal roman text-base tracking-normal leading-normal bg-white text-grey-darker antialiased">

--- a/src/stubs/views/auth/layouts/partials/_header.blade.php
+++ b/src/stubs/views/auth/layouts/partials/_header.blade.php
@@ -28,8 +28,8 @@
                             @csrf
                         </form>
                     @else
-                        <li class="mb-6 md:mr-6 md:mb-0"><a class="block md:inline text-blue-dark no-underline hover:underline" href="{{ route('login') }}">Login</a></li>
-                        <li class="mb-6 md:mr-6 md:mb-0"><a class="block md:inline text-blue-dark no-underline hover:underline" href="{{ route('register') }}">Register</a></li>
+                        <li class="mb-6 md:mr-6 md:mb-0"><a class="block md:inline text-blue-dark no-underline hover:underline" href="{{ route('login') }}">Sign in</a></li>
+                        <li class="mb-6 md:mr-6 md:mb-0"><a class="block md:inline text-blue-dark no-underline hover:underline" href="{{ route('register') }}">Sign up</a></li>
                     @endauth
                 </ul>
             </div>

--- a/src/stubs/views/auth/welcome.blade.php
+++ b/src/stubs/views/auth/welcome.blade.php
@@ -25,6 +25,7 @@
             <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://laravel.com/docs">Documentation</a></li>
             <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://laracasts.com">Laracasts</a></li>
             <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://laravel-news.com">News</a></li>
+            <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://nova.laravel.com">Nova</a></li>
             <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://forge.laravel.com">Forge</a></li>
             <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://github.com/laravel/laravel">GitHub</a></li>
         </ul>

--- a/src/stubs/views/auth/welcome.blade.php
+++ b/src/stubs/views/auth/welcome.blade.php
@@ -19,7 +19,7 @@
             </div>
         @endif
 
-        <div class="font-light text-5xl mb-6">{{ config('app.name') }}</div>
+        <h1 class="font-light text-5xl mb-6">{{ config('app.name') }}</h1>
 
         <ul class="list-reset flex flex-col sm:flex-row items-center -mb-4 sm:-mr-6">
             <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://laravel.com/docs">Documentation</a></li>

--- a/src/stubs/views/auth/welcome.blade.php
+++ b/src/stubs/views/auth/welcome.blade.php
@@ -12,8 +12,8 @@
                     @auth
                         <li class="mr-6"><a class="font-semibold text-blue-dark no-underline hover:underline" href="{{ route('home') }}">Home</a></li>
                     @else
-                        <li class="mr-6"><a class="font-semibold text-blue-dark no-underline hover:underline" href="{{ route('login') }}">Login</a></li>
-                        <li class="mr-6"><a class="font-semibold text-blue-dark no-underline hover:underline" href="{{ route('register') }}">Register</a></li>
+                        <li class="mr-6"><a class="font-semibold text-blue-dark no-underline hover:underline" href="{{ route('login') }}">Sign in</a></li>
+                        <li class="mr-6"><a class="font-semibold text-blue-dark no-underline hover:underline" href="{{ route('register') }}">Sign up</a></li>
                     @endauth
                 </ul>
             </div>

--- a/src/stubs/views/default/welcome.blade.php
+++ b/src/stubs/views/default/welcome.blade.php
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
     <head>
-        <meta charset="utf-8" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" />
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
         <title>{{ config('app.name') }}</title>
 
-        <link href="{{ mix('css/app.css') }}" rel="stylesheet" />
+        <link href="{{ mix('css/app.css') }}" rel="stylesheet">
     </head>
     <body class="font-sans font-normal roman text-base tracking-normal leading-normal bg-white text-grey-darker antialiased">
         <div class="min-h-full h-full w-full flex flex-col items-center justify-center">

--- a/src/stubs/views/default/welcome.blade.php
+++ b/src/stubs/views/default/welcome.blade.php
@@ -11,7 +11,7 @@
     </head>
     <body class="font-sans font-normal roman text-base tracking-normal leading-normal bg-white text-grey-darker antialiased">
         <div class="min-h-full h-full w-full flex flex-col items-center justify-center">
-            <div class="font-light text-5xl mb-6">{{ config('app.name') }}</div>
+            <h1 class="font-light text-5xl mb-6">{{ config('app.name') }}</h1>
 
             <ul class="list-reset flex flex-col sm:flex-row items-center -mb-4 sm:-mr-6">
                 <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://laravel.com/docs">Documentation</a></li>

--- a/src/stubs/views/default/welcome.blade.php
+++ b/src/stubs/views/default/welcome.blade.php
@@ -17,6 +17,7 @@
                 <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://laravel.com/docs">Documentation</a></li>
                 <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://laracasts.com">Laracasts</a></li>
                 <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://laravel-news.com">News</a></li>
+                <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://nova.laravel.com">News</a></li>
                 <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://forge.laravel.com">Forge</a></li>
                 <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://github.com/laravel/laravel">GitHub</a></li>
             </ul>

--- a/src/stubs/views/default/welcome.blade.php
+++ b/src/stubs/views/default/welcome.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ app()->getLocale() }}">
+<html lang="{{ app()->getLocale() }}" class="h-full">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -9,7 +9,7 @@
 
         <link href="{{ mix('css/app.css') }}" rel="stylesheet">
     </head>
-    <body class="font-sans font-normal roman text-base tracking-normal leading-normal bg-white text-grey-darker antialiased">
+    <body class="font-sans font-normal roman text-base tracking-normal leading-normal bg-white text-grey-darker antialiased min-h-full h-full">
         <div class="min-h-full h-full w-full flex flex-col items-center justify-center">
             <h1 class="font-light text-5xl mb-6">{{ config('app.name') }}</h1>
 

--- a/src/stubs/views/default/welcome.blade.php
+++ b/src/stubs/views/default/welcome.blade.php
@@ -17,7 +17,7 @@
                 <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://laravel.com/docs">Documentation</a></li>
                 <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://laracasts.com">Laracasts</a></li>
                 <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://laravel-news.com">News</a></li>
-                <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://nova.laravel.com">News</a></li>
+                <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://nova.laravel.com">Nova</a></li>
                 <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://forge.laravel.com">Forge</a></li>
                 <li class="mb-4 sm:mr-6"><a class="text-blue-dark no-underline hover:underline" href="https://github.com/laravel/laravel">GitHub</a></li>
             </ul>

--- a/src/stubs/views/default/welcome.blade.php
+++ b/src/stubs/views/default/welcome.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ app()->getLocale() }}" class="h-full">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-full">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/stubs/webpack.stub
+++ b/src/stubs/webpack.stub
@@ -1,7 +1,6 @@
-let mix = require('laravel-mix');
-let tailwind = require('tailwindcss');
-
-require('laravel-mix-purgecss');
+const mix = require('laravel-mix')
+const tailwind = require('tailwindcss')
+require('laravel-mix-purgecss')
 
 mix.setPublicPath('public')
   .less('resources/less/app.less', 'public/css')
@@ -10,8 +9,8 @@ mix.setPublicPath('public')
     postCss: [
       tailwind('./tailwind.js'),
     ]
-  });
+  })
 
 if (mix.inProduction()) {
-  mix.purgeCss().version();
+  mix.purgeCss().version()
 }

--- a/src/stubs/webpack.stub
+++ b/src/stubs/webpack.stub
@@ -4,8 +4,8 @@ let tailwind = require('tailwindcss');
 require('laravel-mix-purgecss');
 
 mix.setPublicPath('public')
-  .less('resources/assets/less/app.less', 'public/css')
-  .js('resources/assets/js/app.js', 'public/js')
+  .less('resources/less/app.less', 'public/css')
+  .js('resources/js/app.js', 'public/js')
   .options({
     postCss: [
       tailwind('./tailwind.js'),


### PR DESCRIPTION
Will merge upon the release of Laravel 5.7, where the `assets` directory is flattened and moved into the `resources` directory.

This PR also adds a pretty sweet custom checkbox, cleans up some of the code, and will also substantiate the `1.0.0` release of this package.