### PR TITLE
[6.0] Add Laravel 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,20 @@
 {
     "name": "zaknesler/tailwind-preset",
     "description": "A Tailwind CSS preset for Laravel.",
-    "keywords": ["laravel", "laravel preset", "preset", "tailwind", "tailwindcss"],
+    "keywords": ["laravel", "preset", "tailwind", "tailwindcss"],
     "license": "MIT",
     "authors": [
         {
             "name": "Zak Nesler",
-            "email": "contact@zaknesler.com"
+            "email": "zak@nesler.dev"
         }
     ],
     "minimum-stability": "stable",
     "require": {
-        "laravel/framework": "^5.5|^6.0"
+        "php": "^7.2",
+        "laravel/ui": "^2.0",
+        "illuminate/filesystem": "^5.5|^6.0|^7.0",
+        "illuminate/support": "^5.5|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": "^7.2",
         "laravel/ui": "^2.0",
-        "illuminate/filesystem": "^5.5|^6.0|^7.0",
-        "illuminate/support": "^5.5|^6.0|^7.0"
+        "illuminate/filesystem": "^7.0",
+        "illuminate/support": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,12 @@
 ## Tailwind CSS Laravel Front-end Preset
 
-[![Latest Stable Version](https://poser.pugx.org/zaknesler/tailwind-preset/v/stable)](https://packagist.org/packages/zaknesler/tailwind-preset)
-[![Total Downloads](https://poser.pugx.org/zaknesler/tailwind-preset/downloads)](https://packagist.org/packages/zaknesler/tailwind-preset)
-[![License](https://poser.pugx.org/zaknesler/tailwind-preset/license)](https://packagist.org/packages/zaknesler/tailwind-preset)
+[![Latest Stable Version](https://poser.pugx.org/zaknesler/tailwind-preset/v/stable)](https://packagist.org/packages/zaknesler/tailwind-preset) [![Total Downloads](https://poser.pugx.org/zaknesler/tailwind-preset/downloads)](https://packagist.org/packages/zaknesler/tailwind-preset) [![License](https://poser.pugx.org/zaknesler/tailwind-preset/license)](https://packagist.org/packages/zaknesler/tailwind-preset)
 
-This is a Laravel front-end preset for [Tailwind CSS](https://tailwindcss.com). This preset replaces the default Bootstrap scaffolding, including the example Vue.js component. It also compiles the assets using [Laravel Mix](https://github.com/jeffreyway/laravel-mix) for convenience and [PurgeCSS](https://github.com/fullhuman/purgecss) to generate the smallest files possible.
+A Laravel 7+ front-end preset for [Tailwind CSS](https://tailwindcss.com). This preset comes bundled with Vue.js and an example component, as well as a responsive navigation menu.
+
+This preset uses Laravel Mix to compile and minify assets. Tailwind 1.4 includes PurgeCSS by default, and this preset is configured to purge the proper files.
+
+> This preset is built for Laravel 7 and up. For Laravel 5 or 6, please use [version 5.0](https://github.com/zaknesler/tailwind-preset/tree/a35309799e93fe384d16ead531add16b98b634e1).
 
 **[Live Demo](https://preset.zaknesler.com)** &middot; [Example Repository](https://github.com/zaknesler/tw-preset-demo)
 
@@ -20,55 +22,56 @@ This is a Laravel front-end preset for [Tailwind CSS](https://tailwindcss.com). 
 </details>
 
 ### Warning
-Laravel presets are meant to be used with a fresh installation of Laravel. Installing this preset will **overwrite** your existing views and assets. Please install with caution.
+Laravel presets are meant to be installed onto a fresh instance of Laravel. This preset will **overwrite** your existing views, assets, and Home controller. Please use with caution.
 
 ### Installation
-To install this preset, you must first require the composer dependency in your application. Laravel will automatically register the service provider for you.
 
-```
-composer require zaknesler/tailwind-preset
-```
+1. Require the composer dependency. Laravel will automatically register the package.
 
-Now, install either the `tailwind` or the `tailwind-auth` preset. The `tailwind-auth` preset includes the authentication scaffolding normally generated when `php artisan make:auth` is executed.
+    ```bash
+   composer require zaknesler/tailwind-preset --dev
+    ```
 
-```
-php artisan preset tailwind
+2. Install the preset:
 
-// or
+    ```bash
+   php artisan ui tailwind --auth
 
-php artisan preset tailwind-auth
-```
+   # Without authentication scaffolding
+   php artisan ui tailwind
+    ```
 
-> **Note:** If you install the `tailwind-auth` preset on a version of Laravel that is older than 5.7, you may delete the `views/auth/verify.blade.php` file, as it will not be used.
 
-Install the NPM packages using your favorite package manager.
+3. Install the npm dependencies using your preferred package manager:
 
-```
-yarn // npm install
-```
+    ```bash
+   # Using Yarn
+   yarn
 
-Now you can compile the assets using any of the Laravel build scripts (dev, prod, watch).
+   # Using npm
+   npm install
+    ```
 
-```
-yarn dev // npm run dev
-```
+4. Compile assets:
 
-Ensure that your database is properly configured and migrated, and you're done!
+    ```bash
+   # Using Yarn
+   yarn dev
+
+   # Using npm
+   npm run dev
+    ```
+
+### Customization
+
+Tailwind is built to be fully customizable. The `tailwind.config.js` file that this preset provides includes a handful of customization options to help get you started, including adding [Inter](https://fonts.google.com/specimen/Inter) to the default font stack, as well as a `theme` color palette, as well as configuration for the [Tailwind custom-forms](https://tailwindcss-custom-forms.netlify.app/) plugin.
+
+The `theme` color palette, by default, simply destructures Tailwind's blue color palette, but can be easily swapped out for your own color keys. For more information, visit the [Tailwind color customization page](https://tailwindcss.com/docs/customizing-colors).
+
+I have tried to design this preset to use as many Tailwind features as possible. This includes using a plugin, overriding default theme values, configuration destructuring, and using PurgeCSS. To get the most out of Tailwind, it is recommended that you take a deep dive into Tailwind's [incredible documentation](https://tailwindcss.com/docs/installation), and more importantly... get your hands dirty with it!
 
 ### Localization
 
-All of the text in the views that this preset provides are configured to be easily translatable. When you install the `tailwind-auth` preset, the file `en.json` will be copied into your application's `resources/lang` directory.
+This preset includes text that is already configured to be easily translated. An `en.json` file will be copied into your application's `resources/lang` directory when you install the authentication scaffolding. This file includes keys for all of the on-screen text found in this preset.
 
-This file includes all of the text found in this package. To update the default English text, simply update the values of any of the key-value pairs. To translate into a different language, duplicate `en.json` and rename it to `{locale}.json`; you can then translate the values into the destination language. For more about localization, please refer to the [Laravel documentation](https://laravel.com/docs/6.x/localization).
-
-### EditorConfig
-
-To ensure proper guide highlighting in your text editor, it is recommended that you add the following to the end of the `.editorconfig` file:
-
-```
-[{tailwind.config.js,webpack.mix.js}]
-indent_style = space
-indent_size = 2
-```
-
-Alternatively, you may reindent both files to use an indent size of four, which is the default in a Laravel project.
+To translate these values, duplicate the `en.json` file and rename it to `{language}.json`, and begin translating the values for each `"key": "value"` pair. For more about localization, please refer to the [Laravel documentation](https://laravel.com/docs/6.x/localization).

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,6 @@
 
 This is a Laravel front-end preset for [Tailwind CSS](https://tailwindcss.com). This preset replaces the default Bootstrap scaffolding, including the example Vue.js component. It also compiles the assets using [Laravel Mix](https://github.com/jeffreyway/laravel-mix) for convenience and [PurgeCSS](https://github.com/fullhuman/purgecss) to generate the smallest files possible.
 
-> **Deprecation Notice** &ndash; As of Laravel 6, all front-end presets have been extracted into the [laravel/ui](https://github.com/laravel/ui) repository. In soon time, a Tailwind preset by the maintainers of Laravel will be created. I will maintain development of this package until a Tailwind preset is created, after which this repository will be archived.
-
-> The reason I am confident in doing this is because I would think that an *official* Tailwind CSS preset would include a well-thought, elegant design. If, however, I am not a fan of the design, I would have no problem with continuing to maintain this package.
-
 **[Live Demo](https://preset.zaknesler.com)** &middot; [Example Repository](https://github.com/zaknesler/tw-preset-demo)
 
 <details>

--- a/readme.md
+++ b/readme.md
@@ -12,12 +12,12 @@ This preset uses Laravel Mix to compile and minify assets. Tailwind 1.4 includes
 
 <details>
 <summary>View screenshots</summary>
-    
-![welcome.blade.php](https://user-images.githubusercontent.com/7189795/59567082-dfddce80-9036-11e9-952d-a535f21478e1.png)
 
-![login.blade.php](https://user-images.githubusercontent.com/7189795/59567081-dfddce80-9036-11e9-8401-257eeb78a07c.png)
+<img alt="Welcome page" src="https://user-images.githubusercontent.com/7189795/80769741-37d0d700-8b1c-11ea-9b16-e76fd8cde9f4.png">
 
-![home.blade.php](https://user-images.githubusercontent.com/7189795/59567080-dfddce80-9036-11e9-81be-20044b2b6cd4.png)
+<img alt="Login page" src="https://user-images.githubusercontent.com/7189795/80769744-399a9a80-8b1c-11ea-9caf-00783b9acc80.png">
+
+<img alt="Home page" src="https://user-images.githubusercontent.com/7189795/80769745-3acbc780-8b1c-11ea-9010-25d38f9a3288.png">
 
 </details>
 

--- a/src/TailwindPreset.php
+++ b/src/TailwindPreset.php
@@ -73,6 +73,7 @@ class TailwindPreset extends Preset
             'welcome.stub',
         ]);
 
+        base_path('vendor/laravel/ui/stubs/migrations/2014_10_12_100000_create_password_resets_table.php')
         file_put_contents(app_path('Http/Controllers/HomeController.php'), static::compileControllerStub());
         copy(__DIR__.'/stubs/en.stub', resource_path('lang/en.json'));
     }

--- a/src/TailwindPreset.php
+++ b/src/TailwindPreset.php
@@ -73,7 +73,11 @@ class TailwindPreset extends Preset
             'welcome.stub',
         ]);
 
-        base_path('vendor/laravel/ui/stubs/migrations/2014_10_12_100000_create_password_resets_table.php')
+        copy(
+            base_path('vendor/laravel/ui/stubs/migrations/2014_10_12_100000_create_password_resets_table.php'),
+            base_path('database/migrations/2014_10_12_100000_create_password_resets_table.php')
+        );
+
         file_put_contents(app_path('Http/Controllers/HomeController.php'), static::compileControllerStub());
         copy(__DIR__.'/stubs/en.stub', resource_path('lang/en.json'));
     }

--- a/src/TailwindPreset.php
+++ b/src/TailwindPreset.php
@@ -3,18 +3,18 @@
 namespace ZakNesler\TailwindPreset;
 
 use Illuminate\Support\Str;
+use Laravel\Ui\Presets\Preset;
 use Illuminate\Container\Container;
-use Illuminate\Support\Facades\File;
-use Illuminate\Foundation\Console\Presets\Preset;
+use Illuminate\Filesystem\Filesystem;
 
-class Tailwind extends Preset
+class TailwindPreset extends Preset
 {
     /**
      * Setup basic assets.
      *
      * @return void
      */
-    private static function setup()
+    protected static function setup()
     {
         static::ensureResourceDirectoriesExist();
         static::updatePackages();
@@ -45,15 +45,15 @@ class Tailwind extends Preset
      *
      * @return void
      */
-    public static function installWithAuth()
+    public static function installAuth()
     {
         static::setup();
         static::installAuthRoutes();
 
-        static::makeViewDirectories([
-            'auth/passwords',
-            'errors',
-            'layouts/partials',
+        static::createResourceDirectories([
+            'views/auth/passwords',
+            'views/errors',
+            'views/layouts/partials',
         ]);
 
         static::installViews('auth', [
@@ -74,7 +74,7 @@ class Tailwind extends Preset
         ]);
 
         file_put_contents(app_path('Http/Controllers/HomeController.php'), static::compileControllerStub());
-        File::copy(__DIR__.'/stubs/en.stub', resource_path('lang/en.json'));
+        copy(__DIR__.'/stubs/en.stub', resource_path('lang/en.json'));
     }
 
     /**
@@ -91,24 +91,25 @@ class Tailwind extends Preset
             'axios' => '^0.19',
             'cross-env' => '^6.0',
             'laravel-mix' => '^5.0',
-            'laravel-mix-purgecss' => '^4.2',
-            'tailwindcss' => '^1.1',
+            'tailwindcss' => '^1.4',
             'vue' => '^2.6',
             'vue-template-compiler' => '^2.6',
         ];
     }
 
     /**
-     * Create view directories.
+     * Create directories if they do not already exist.
      *
-     * @param  array  $directories
+     * @param  array  $dirs
      * @return void
      */
-    protected static function makeViewDirectories($directories)
+    protected static function createResourceDirectories($dirs)
     {
-        foreach ($directories as $directory) {
-            if (! is_dir($directory = resource_path('views/'.$directory))) {
-                File::makeDirectory($directory, 0755, true);
+        $filesystem = new Filesystem;
+
+        foreach ($dirs as $dir) {
+            if (! is_dir($dir = resource_path($dir))) {
+                $filesystem->makeDirectory($dir, 0755, true);
             }
         }
     }
@@ -116,15 +117,17 @@ class Tailwind extends Preset
     /**
      * Copy the view stubs over to the application and rename them.
      *
-     * @param  string  $baseDirectory
+     * @param  string  $baseDir
      * @param  array  $views
      * @return void
      */
-    protected static function installViews($baseDirectory, $views)
+    protected static function installViews($baseDir, $views)
     {
+        $filesystem = new Filesystem;
+
         foreach ($views as $view) {
-            File::copy(
-                __DIR__.'/stubs/views/'.$baseDirectory.'/'.$view,
+            $filesystem->copy(
+                __DIR__.'/stubs/views/'.$baseDir.'/'.$view,
                 resource_path('views/'.str_replace('stub', 'blade.php', $view))
             );
         }
@@ -169,10 +172,12 @@ class Tailwind extends Preset
      */
     protected static function ensureResourceDirectoriesExist()
     {
+        $filesystem = new Filesystem;
+
         collect(['css', 'js/components'])
-            ->each(function ($directory) {
-                if (! is_dir(resource_path($directory))) {
-                    File::makeDirectory(resource_path($directory), 0755, true);
+            ->each(function ($dir) use ($filesystem) {
+                if (! is_dir(resource_path($dir))) {
+                    $filesystem->makeDirectory(resource_path($dir), 0755, true);
                 }
             });
     }
@@ -184,13 +189,13 @@ class Tailwind extends Preset
      */
     protected static function installScripts()
     {
-        File::delete(base_path('webpack.mix.js'));
+        (new Filesystem)->delete(base_path('webpack.mix.js'));
 
-        File::copy(__DIR__.'/stubs/tailwind.stub', base_path('tailwind.config.js'));
-        File::copy(__DIR__.'/stubs/webpack.stub', base_path('webpack.mix.js'));
+        copy(__DIR__.'/stubs/tailwind.stub', base_path('tailwind.config.js'));
+        copy(__DIR__.'/stubs/webpack.stub', base_path('webpack.mix.js'));
 
-        File::copy(__DIR__.'/stubs/js/app.stub', resource_path('js/app.js'));
-        File::copy(__DIR__.'/stubs/js/bootstrap.stub', resource_path('js/bootstrap.js'));
+        copy(__DIR__.'/stubs/js/app.stub', resource_path('js/app.js'));
+        copy(__DIR__.'/stubs/js/bootstrap.stub', resource_path('js/bootstrap.js'));
     }
 
     /**
@@ -200,7 +205,7 @@ class Tailwind extends Preset
      */
     protected static function installStyles()
     {
-        File::copy(__DIR__.'/stubs/css/tailwind.stub', resource_path('css/tailwind.css'));
+        copy(__DIR__.'/stubs/css/tailwind.stub', resource_path('css/tailwind.css'));
     }
 
     /**
@@ -210,7 +215,7 @@ class Tailwind extends Preset
      */
     protected static function updateExampleComponent()
     {
-        File::copy(
+        copy(
             __DIR__.'/stubs/js/components/ExampleComponent.stub',
             resource_path('js/components/ExampleComponent.vue')
         );

--- a/src/TailwindServiceProvider.php
+++ b/src/TailwindServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace ZakNesler\TailwindPreset;
 
+use Laravel\Ui\UiCommand;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Foundation\Console\PresetCommand;
 
 class TailwindServiceProvider extends ServiceProvider
 {
@@ -14,28 +14,19 @@ class TailwindServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        PresetCommand::macro('tailwind', function ($command) {
-            Tailwind::install();
+        UiCommand::macro('tailwind', function ($command) {
+            if ($command->option('auth')) {
+                TailwindPreset::installAuth();
+                $command->callSilent('ui:controllers');
 
-            $this->installMessage($command);
+                $command->info('Tailwind authentication scaffolding installed successfully.');
+            } else {
+                TailwindPreset::install();
+
+                $command->info('Tailwind scaffolding installed successfully.');
+            }
+
+            $command->comment('Please run "yarn && yarn dev" or "npm install && npm run dev" to compile your fresh scaffolding.');
         });
-
-        PresetCommand::macro('tailwind-auth', function ($command) {
-            Tailwind::installWithAuth();
-
-            $this->installMessage($command);
-        });
-    }
-
-    /**
-     * Print message after successful installation.
-     *
-     * @param  \Illuminate\Console\Command  $command
-     * @return void
-     */
-    protected function installMessage($command)
-    {
-        $command->info('Tailwind scaffolding installed successfully.');
-        $command->comment('Please run "yarn && yarn dev" or "npm install && npm run dev" to compile your fresh scaffolding.');
     }
 }

--- a/src/stubs/controllers/HomeController.stub
+++ b/src/stubs/controllers/HomeController.stub
@@ -19,7 +19,7 @@ class HomeController extends Controller
     /**
      * Show the application dashboard.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Contracts\Support\Renderable
      */
     public function index()
     {

--- a/src/stubs/css/tailwind.stub
+++ b/src/stubs/css/tailwind.stub
@@ -5,14 +5,8 @@
 @tailwind base;
 @tailwind components;
 
-@variants focus {
-    .shadow-transition {
-        transition: box-shadow 100ms ease-in-out;
-    }
-}
-
 .btn {
-    @apply px-6 py-3 bg-brand-500 font-semibold text-white rounded-lg border-none appearance-none;
+    @apply px-6 py-3 bg-brand-500 font-semibold text-white rounded-lg border-none appearance-none transition duration-100 transition-shadow;
 }
 
 .btn:hover {
@@ -20,7 +14,7 @@
 }
 
 .btn:focus {
-    @apply outline-none shadow-outline shadow-transition;
+    @apply outline-none shadow-outline;
 }
 
 @tailwind utilities;

--- a/src/stubs/en.stub
+++ b/src/stubs/en.stub
@@ -11,7 +11,7 @@
     "Create account": "Create account",
     "Didn't get the email?": "Didn't get the email?",
     "Email": "Email",
-    "Enter your email address and we'll send you a link to reset your password": "Enter your email address and we'll send you a link to reset your password",
+    "Enter your email and we'll send you a link to reset your password": "Enter your email and we'll send you a link to reset your password",
     "Forgot password?": "Forgot password?",
     "Have an account?": "Have an account?",
     "Home": "Home",

--- a/src/stubs/js/components/ExampleComponent.stub
+++ b/src/stubs/js/components/ExampleComponent.stub
@@ -14,7 +14,7 @@
                 type: String,
                 required: false,
                 default: 'Example Component'
-            }
+            },
         },
 
         mounted() {

--- a/src/stubs/tailwind.stub
+++ b/src/stubs/tailwind.stub
@@ -35,4 +35,10 @@ module.exports = {
   plugins: [
     require('@tailwindcss/custom-forms'),
   ],
+  purge: [
+    './app/**/*.php',
+    './resources/**/*.vue',
+    './resources/**/*.js',
+    './resources/**/*.php',
+  ],
 }

--- a/src/stubs/tailwind.stub
+++ b/src/stubs/tailwind.stub
@@ -1,44 +1,55 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
-  theme: {
-    extend: {
-      colors: {
-        brand: { ...defaultTheme.colors.teal },
-      },
-      boxShadow: theme => ({
-        outline: `0 0 0 3px ${theme('colors.brand.500')}60`,
-      }),
+    theme: {
+        extend: {
+            colors: {
+                brand: { ...defaultTheme.colors.blue },
+            },
+
+            fontFamily: {
+                sans: [ 'Inter', ...defaultTheme.fontFamily.sans ],
+            },
+
+            boxShadow: theme => ({
+                outline: `0 0 0 3px ${theme('colors.brand.500')}60`,
+            }),
+        },
+
+        customForms: theme => ({
+            default: {
+                'input, textarea, multiselect, select': {
+                    borderRadius: theme('borderRadius.lg'),
+                },
+
+                'input, textarea, multiselect, select, checkbox, radio': {
+                    '&:focus': {
+                        borderColor: theme('colors.brand.400'),
+                        boxShadow: theme('boxShadow.outline'),
+                        transition: 'box-shadow 100ms ease-in-out',
+                    },
+                },
+
+                'checkbox, radio': {
+                    '&:checked:focus': {
+                        borderColor: theme('colors.brand.500'),
+                        backgroundColor: theme('colors.brand.500'),
+                    },
+                },
+            },
+        }),
     },
-    customForms: theme => ({
-      default: {
-        'input, textarea, multiselect, select': {
-          borderRadius: theme('borderRadius.lg'),
-        },
-        'input, textarea, multiselect, select, checkbox, radio': {
-          '&:focus': {
-            borderColor: theme('colors.brand.400'),
-            boxShadow: theme('boxShadow.outline'),
-            transition: 'box-shadow 100ms ease-in-out',
-          },
-        },
-        'checkbox, radio': {
-          '&:checked:focus': {
-            borderColor: theme('colors.brand.500'),
-            backgroundColor: theme('colors.brand.500'),
-          },
-        },
-      },
-    }),
-  },
-  variants: {},
-  plugins: [
-    require('@tailwindcss/custom-forms'),
-  ],
-  purge: [
-    './app/**/*.php',
-    './resources/**/*.vue',
-    './resources/**/*.js',
-    './resources/**/*.php',
-  ],
+
+    variants: {},
+
+    plugins: [
+        require('@tailwindcss/custom-forms'),
+    ],
+
+    purge: [
+        './app/**/*.php',
+        './resources/**/*.vue',
+        './resources/**/*.js',
+        './resources/**/*.php',
+    ],
 }

--- a/src/stubs/views/auth/auth/login.stub
+++ b/src/stubs/views/auth/auth/login.stub
@@ -4,58 +4,72 @@
 @section('show-header', false)
 
 @section('content-full')
-    <div class="h-full flex">
-        <div class="p-6 m-auto max-w-xs w-full">
+    <div class="h-full flex bg-gray-100">
+        <div class="p-6 space-y-6 m-auto max-w-xs w-full">
             <div class="flex items-center justify-center">
-                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">{{ config('app.name') }}</a>
+                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">
+                    {{ config('app.name') }}
+                </a>
             </div>
 
-            <div class="mt-6 mx-auto max-w-xs text-center text-gray-600">
+            <div class="mx-auto text-center text-gray-600">
                 {{ __('Sign in to your account') }}
             </div>
 
-            <form action="{{ route('login') }}" method="POST" class="mt-6">
+            <form action="{{ route('login') }}" method="POST" class="space-y-6">
                 @csrf
 
-                <div>
-                    <label>
-                        <span class="text-xs font-medium text-gray-600 {{ $errors->first('email', 'text-red-700') }}">{{ __('Email') }}</span>
-                        <input
-                            autofocus
-                            required
-                            tabindex="1"
-                            type="email"
-                            name="email"
-                            value="{{ old('email') }}"
-                            class="mt-1 form-input block w-full {{ $errors->first('email', 'border-red-500') }}"
-                            placeholder="you@example.com"
-                        />
+                <div class="space-y-4">
+                    <div>
+                        <label>
+                            <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('email', 'text-red-700') }}">
+                                {{ __('Email') }}
+                            </div>
 
-                        @if ($errors->has('email'))
-                            <div class="px-3 py-2 mt-2 text-xs font-semibold bg-red-100 text-red-700 rounded-lg">{{ $errors->first('email') }}</div>
-                        @endif
-                    </label>
+                            <input
+                                autofocus
+                                required
+                                tabindex="1"
+                                type="email"
+                                name="email"
+                                value="{{ old('email') }}"
+                                class="form-input block w-full {{ $errors->first('email', 'border-red-500') }}"
+                                placeholder="you@example.com"
+                            />
+
+                            @if ($errors->has('email'))
+                                <div class="px-3 py-2 mt-2 text-xs font-semibold border border-red-200 bg-red-100 text-red-700 rounded-lg">
+                                    {{ $errors->first('email') }}
+                                </div>
+                            @endif
+                        </label>
+                    </div>
+
+                    <div>
+                        <label>
+                            <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('password', 'text-red-700') }}">
+                                {{ __('Password') }}
+                            </div>
+
+                            <input
+                                required
+                                tabindex="2"
+                                type="password"
+                                name="password"
+                                class="form-input block w-full {{ $errors->first('password', 'border-red-500') }}"
+                                placeholder="••••••••"
+                            />
+
+                            @if ($errors->has('password'))
+                                <div class="px-3 py-2 mt-2 text-xs font-semibold border border-red-200 bg-red-100 text-red-700 rounded-lg">
+                                    {{ $errors->first('password') }}
+                                </div>
+                            @endif
+                        </label>
+                    </div>
                 </div>
 
-                <div class="mt-3">
-                    <label>
-                        <span class="text-xs font-medium text-gray-600 {{ $errors->first('password', 'text-red-700') }}">{{ __('Password') }}</span>
-                        <input
-                            required
-                            tabindex="2"
-                            type="password"
-                            name="password"
-                            class="mt-1 form-input block w-full {{ $errors->first('password', 'border-red-500') }}"
-                            placeholder="••••••••"
-                        />
-
-                        @if ($errors->has('password'))
-                            <div class="px-3 py-2 mt-2 text-xs font-semibold bg-red-100 text-red-700 rounded-lg">{{ $errors->first('password') }}</div>
-                        @endif
-                    </label>
-                </div>
-
-                <div class="mt-6 flex items-center justify-between">
+                <div class="flex items-center justify-between">
                     <label class="flex items-center">
                         <input
                             checked
@@ -64,27 +78,28 @@
                             name="remember"
                             class="form-checkbox focus:shadow-transition text-brand-500 cursor-pointer"
                         />
-                        <span class="ml-2 text-gray-600 text-sm select-none">{{ __('Remember me') }}</span>
+
+                        <span class="ml-2 text-gray-600 text-sm select-none">
+                            {{ __('Remember me') }}
+                        </span>
                     </label>
 
-                    <button tabindex="4" class="btn px-5 py-2 text-sm">{{ __('Sign in') }}</button>
+                    <button tabindex="4" class="btn px-5 py-2 text-sm">
+                        {{ __('Sign in') }}
+                    </button>
                 </div>
 
-                <div class="mt-6 text-sm text-center">
+                <div class="text-sm text-center">
                     @if (Route::has('register'))
-                        <a href="{{ route('register') }}" class="font-semibold text-gray-700 hover:text-gray-800 hover:underline">
-                            {{ __('Create account') }}
-                        </a>
+                        <a tabindex="5" href="{{ route('register') }}" class="font-semibold text-gray-700 hover:text-gray-800 hover:underline">{{ __('Create account') }}</a>
                     @endif
 
-                    @if (Route::has('register') && Route::has('password.request'))
+                    @if (Route::has('register') and Route::has('password.request'))
                         <span class="mx-1 text-gray-500">&middot;</span>
                     @endif
 
                     @if (Route::has('password.request'))
-                        <a href="{{ route('password.request') }}" class="text-gray-700 hover:text-gray-800 hover:underline">
-                            {{ __('Forgot password?') }}
-                        </a>
+                        <a tabindex="6" href="{{ route('password.request') }}" class="text-gray-700 hover:text-gray-800 hover:underline">{{ __('Forgot password?') }}</a>
                     @endif
                 </div>
             </form>

--- a/src/stubs/views/auth/auth/passwords/confirm.stub
+++ b/src/stubs/views/auth/auth/passwords/confirm.stub
@@ -4,28 +4,27 @@
 @section('show-header', false)
 
 @section('content-full')
-    <div class="h-full flex">
-        <div class="p-6 m-auto max-w-xs w-full">
+    <div class="h-full flex bg-gray-100">
+        <div class="p-6 space-y-6 m-auto max-w-xs w-full">
             <div class="flex items-center justify-center">
-                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">{{ config('app.name') }}</a>
+                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">
+                    {{ config('app.name') }}
+                </a>
             </div>
 
-            <div class="mt-6 text-center text-gray-600">
+            <div class="mx-auto text-center text-gray-600">
                 {{ __('Please confirm your password before continuing') }}
             </div>
 
-            @if (session('status'))
-                <div class="mt-6 px-4 py-3 bg-gray-100 text-gray-700 rounded-lg text-sm">
-                    {{ session('status') }}
-                </div>
-            @endif
-
-            <form action="{{ route('password.confirm') }}" method="POST" class="mt-6">
+            <form action="{{ route('password.confirm') }}" method="POST" class="space-y-6">
                 @csrf
 
                 <div>
                     <label>
-                        <span class="text-xs font-medium text-gray-600 {{ $errors->first('password', 'text-red-700') }}">{{ __('Password') }}</span>
+                        <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('password', 'text-red-700') }}">
+                            {{ __('Email') }}
+                        </div>
+
                         <input
                             autofocus
                             required
@@ -33,22 +32,30 @@
                             type="password"
                             name="password"
                             value="{{ old('password') }}"
-                            class="mt-1 form-input block w-full {{ $errors->first('password', 'border-red-500') }}"
+                            class="form-input block w-full {{ $errors->first('password', 'border-red-500') }}"
                             placeholder="••••••••"
                         />
 
                         @if ($errors->has('password'))
-                            <div class="px-3 py-2 mt-2 text-xs font-semibold bg-red-100 text-red-700 rounded-lg">{{ $errors->first('password') }}</div>
+                            <div class="px-3 py-2 mt-2 text-xs font-semibold border border-red-200 bg-red-100 text-red-700 rounded-lg">
+                                {{ $errors->first('password') }}
+                            </div>
                         @endif
                     </label>
                 </div>
 
-                <div class="mt-6 text-sm flex items-center justify-between">
-                    @if (Route::has('password.request'))
-                        <a tabindex="3" href="{{ route('password.request') }}" class="text-gray-700 font-semibold hover:text-gray-800 hover:underline">{{ __('Forgot password?') }}</a>
-                    @endif
+                <div class="flex items-center justify-between">
+                    <div class="text-sm">
+                        @if (Route::has('password.request'))
+                            <a tabindex="3" href="{{ route('password.request') }}" class="font-semibold text-gray-700 hover:text-gray-800 hover:underline">
+                                {{ __('Forgot password?') }}
+                            </a>
+                        @endif
+                    </div>
 
-                    <button tabindex="2" class="btn px-5 py-2">{{ __('Confirm') }}</button>
+                    <button tabindex="2" class="btn px-5 py-2 text-sm">
+                        {{ __('Confirm') }}
+                    </button>
                 </div>
             </form>
         </div>

--- a/src/stubs/views/auth/auth/passwords/confirm.stub
+++ b/src/stubs/views/auth/auth/passwords/confirm.stub
@@ -22,7 +22,7 @@
                 <div>
                     <label>
                         <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('password', 'text-red-700') }}">
-                            {{ __('Email') }}
+                            {{ __('Password') }}
                         </div>
 
                         <input

--- a/src/stubs/views/auth/auth/passwords/email.stub
+++ b/src/stubs/views/auth/auth/passwords/email.stub
@@ -4,28 +4,33 @@
 @section('show-header', false)
 
 @section('content-full')
-    <div class="h-full flex">
-        <div class="p-6 m-auto max-w-xs w-full">
+    <div class="h-full flex bg-gray-100">
+        <div class="p-6 space-y-6 m-auto max-w-xs w-full">
             <div class="flex items-center justify-center">
-                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">{{ config('app.name') }}</a>
+                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">
+                    {{ config('app.name') }}
+                </a>
             </div>
 
-            <div class="mt-6 text-center text-gray-600">
-                {{ __('Enter your email address and we\'ll send you a link to reset your password') }}
+            <div class="mx-auto text-center text-gray-600">
+                {{ __('Enter your email and we\'ll send you a link to reset your password') }}
             </div>
 
             @if (session('status'))
-                <div class="mt-6 px-4 py-3 bg-gray-100 text-gray-700 rounded-lg text-sm">
+                <div class="px-4 py-3 text-sm rounded-lg shadow-sm bg-white text-gray-700">
                     {{ session('status') }}
                 </div>
             @endif
 
-            <form action="{{ route('password.email') }}" method="POST" class="mt-6">
+            <form action="{{ route('password.email') }}" method="POST" class="space-y-6">
                 @csrf
 
                 <div>
                     <label>
-                        <span class="text-xs font-medium text-gray-600 {{ $errors->first('email', 'text-red-700') }}">{{ __('Email') }}</span>
+                        <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('email', 'text-red-700') }}">
+                            {{ __('Email') }}
+                        </div>
+
                         <input
                             autofocus
                             required
@@ -33,23 +38,30 @@
                             type="email"
                             name="email"
                             value="{{ old('email') }}"
-                            class="mt-1 form-input block w-full {{ $errors->first('email', 'border-red-500') }}"
+                            class="form-input block w-full {{ $errors->first('email', 'border-red-500') }}"
                             placeholder="you@example.com"
                         />
 
                         @if ($errors->has('email'))
-                            <div class="px-3 py-2 mt-2 text-xs font-semibold bg-red-100 text-red-700 rounded-lg">{{ $errors->first('email') }}</div>
+                            <div class="px-3 py-2 mt-2 text-xs font-semibold border border-red-200 bg-red-100 text-red-700 rounded-lg">
+                                {{ $errors->first('email') }}
+                            </div>
                         @endif
                     </label>
                 </div>
 
-                <div class="mt-6 text-sm flex items-center justify-between">
-                    <div>
+                <div class="flex items-center justify-between">
+                    <div class="text-sm">
                         {{ __('Remember it?') }}
-                        <a tabindex="3" href="{{ route('login') }}" class="font-semibold text-gray-700 hover:text-gray-800 hover:underline">{{ __('Sign in') }}</a>
+
+                        <a tabindex="3" href="{{ route('login') }}" class="font-semibold text-gray-700 hover:text-gray-800 hover:underline">
+                            {{ __('Sign in') }}
+                        </a>
                     </div>
 
-                    <button tabindex="2" class="btn px-5 py-2">{{ __('Send Link') }}</button>
+                    <button tabindex="2" class="btn px-5 py-2 text-sm">
+                        {{ __('Send Link') }}
+                    </button>
                 </div>
             </form>
         </div>

--- a/src/stubs/views/auth/auth/passwords/reset.stub
+++ b/src/stubs/views/auth/auth/passwords/reset.stub
@@ -4,79 +4,100 @@
 @section('show-header', false)
 
 @section('content-full')
-    <div class="h-full flex">
-        <div class="p-6 m-auto max-w-xs w-full">
+    <div class="h-full flex bg-gray-100">
+        <div class="p-6 space-y-6 m-auto max-w-xs w-full">
             <div class="flex items-center justify-center">
-                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">{{ config('app.name') }}</a>
+                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">
+                    {{ config('app.name') }}
+                </a>
             </div>
 
-            <div class="mt-6 mx-auto max-w-xs text-center text-gray-600">
+            <div class="mx-auto text-center text-gray-600">
                 {{ __('Reset your password') }}
             </div>
 
-            <form action="{{ route('password.request') }}" method="POST" class="mt-6">
+            <form action="{{ route('password.request') }}" method="POST" class="space-y-6">
                 @csrf
 
-                <input type="hidden" name="token" value="{{ $token }}" />
+                <input type="hidden" name="token" value="{{ $token }}">
 
-                <div>
-                    <label>
-                        <span class="text-xs font-medium text-gray-600 {{ $errors->first('email', 'text-red-700') }}">{{ __('Email') }}</span>
-                        <input
-                            autofocus
-                            required
-                            tabindex="1"
-                            type="email"
-                            name="email"
-                            value="{{ old('email') ?? $email }}"
-                            class="mt-1 form-input block w-full {{ $errors->first('email', 'border-red-500') }}"
-                            placeholder="you@example.com"
-                        />
+                <div class="space-y-4">
+                    <div>
+                        <label>
+                            <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('email', 'text-red-700') }}">
+                                {{ __('Email') }}
+                            </div>
 
-                        @if ($errors->has('email'))
-                            <div class="px-3 py-2 mt-2 text-xs font-semibold bg-red-100 text-red-700 rounded-lg">{{ $errors->first('email') }}</div>
-                        @endif
-                    </label>
+                            <input
+                                autofocus
+                                required
+                                tabindex="1"
+                                type="email"
+                                name="email"
+                                value="{{ old('email') ?? $email }}"
+                                class="form-input block w-full {{ $errors->first('email', 'border-red-500') }}"
+                                placeholder="you@example.com"
+                            />
+
+                            @if ($errors->has('email'))
+                                <div class="px-3 py-2 mt-2 text-xs font-semibold border border-red-200 bg-red-100 text-red-700 rounded-lg">
+                                    {{ $errors->first('email') }}
+                                </div>
+                            @endif
+                        </label>
+                    </div>
+
+                    <div>
+                        <label>
+                            <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('password', 'text-red-700') }}">
+                                {{ __('Password') }}
+                            </div>
+
+                            <input
+                                required
+                                tabindex="2"
+                                type="password"
+                                name="password"
+                                class="form-input block w-full {{ $errors->first('password', 'border-red-500') }}"
+                                placeholder="••••••••"
+                            />
+
+                            @if ($errors->has('password'))
+                                <div class="px-3 py-2 mt-2 text-xs font-semibold border border-red-200 bg-red-100 text-red-700 rounded-lg">
+                                    {{ $errors->first('password') }}
+                                </div>
+                            @endif
+                        </label>
+                    </div>
+
+                    <div>
+                        <label>
+                            <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('password_confirmation', 'text-red-700') }}">
+                                {{ __('Confirm Password') }}
+                            </div>
+
+                            <input
+                                required
+                                tabindex="3"
+                                type="password"
+                                name="password_confirmation"
+                                class="form-input block w-full {{ $errors->first('password_confirmation', 'border-red-500') }}"
+                                placeholder="••••••••"
+                            />
+
+                            @if ($errors->has('password_confirmation'))
+                                <div class="px-3 py-2 mt-2 text-xs font-semibold border border-red-200 bg-red-100 text-red-700 rounded-lg">
+                                    {{ $errors->first('password_confirmation') }}
+                                </div>
+                            @endif
+                        </label>
+                    </div>
                 </div>
 
-                <div class="mt-3">
-                    <label>
-                        <span class="text-xs font-medium text-gray-600 {{ $errors->first('password', 'text-red-700') }}">{{ __('New Password') }}</span>
-                        <input
-                            required
-                            tabindex="2"
-                            type="password"
-                            name="password"
-                            class="mt-1 form-input block w-full {{ $errors->first('password', 'border-red-500') }}"
-                            placeholder="••••••••"
-                        />
-
-                        @if ($errors->has('password'))
-                            <div class="px-3 py-2 mt-2 text-xs font-semibold bg-red-100 text-red-700 rounded-lg">{{ $errors->first('password') }}</div>
-                        @endif
-                    </label>
-                </div>
-
-                <div class="mt-3">
-                    <label>
-                        <span class="text-xs font-medium text-gray-600 {{ $errors->first('password_confirmation', 'text-red-700') }}">{{ __('Confirm New Password') }}</span>
-                        <input
-                            required
-                            tabindex="3"
-                            type="password"
-                            name="password_confirmation"
-                            class="mt-1 form-input block w-full {{ $errors->first('password_confirmation', 'border-red-500') }}"
-                            placeholder="••••••••"
-                        />
-
-                        @if ($errors->has('password_confirmation'))
-                            <div class="px-3 py-2 mt-2 text-xs font-semibold bg-red-100 text-red-700 rounded-lg">{{ $errors->first('password_confirmation') }}</div>
-                        @endif
-                    </label>
-                </div>
-
-                <div class="mt-6 text-sm text-right">
-                    <button tabindex="4" class="btn px-5 py-2">{{ __('Reset password') }}</button>
+                <div class="text-right">
+                    <button tabindex="4" class="btn px-5 py-2 text-sm">
+                        {{ __('Reset password') }}
+                    </button>
                 </div>
             </form>
         </div>

--- a/src/stubs/views/auth/auth/register.stub
+++ b/src/stubs/views/auth/auth/register.stub
@@ -4,101 +4,130 @@
 @section('show-header', false)
 
 @section('content-full')
-    <div class="h-full flex">
-        <div class="p-6 m-auto max-w-xs w-full">
+    <div class="h-full flex bg-gray-100">
+        <div class="p-6 space-y-6 m-auto max-w-xs w-full">
             <div class="flex items-center justify-center">
-                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">{{ config('app.name') }}</a>
+                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">
+                    {{ config('app.name') }}
+                </a>
             </div>
 
-            <div class="mt-6 mx-auto max-w-xs text-center text-gray-600">
+            <div class="mx-auto text-center text-gray-600">
                 {{ __('Create a new account') }}
             </div>
 
-            <form action="{{ route('register') }}" method="POST" class="mt-6">
+            <form action="{{ route('register') }}" method="POST" class="space-y-6">
                 @csrf
 
-                <div>
-                    <label>
-                        <span class="text-xs font-medium text-gray-600 {{ $errors->first('name', 'text-red-700') }}">{{ __('Name') }}</span>
-                        <input
-                            autofocus
-                            required
-                            tabindex="1"
-                            type="text"
-                            name="name"
-                            value="{{ old('name') }}"
-                            class="mt-1 form-input block w-full {{ $errors->first('name', 'border-red-500') }}"
-                            placeholder="John Doe"
-                        />
-
-                        @if ($errors->has('name'))
-                            <div class="px-3 py-2 mt-2 text-xs font-semibold bg-red-100 text-red-700 rounded-lg">{{ $errors->first('name') }}</div>
-                        @endif
-                    </label>
-                </div>
-
-                <div class="mt-3">
-                    <label>
-                        <span class="text-xs font-medium text-gray-600 {{ $errors->first('email', 'text-red-700') }}">{{ __('Email') }}</span>
-                        <input
-                            required
-                            tabindex="2"
-                            type="email"
-                            name="email"
-                            value="{{ old('email') }}"
-                            class="mt-1 form-input block w-full {{ $errors->first('email', 'border-red-500') }}"
-                            placeholder="you@example.com"
-                        />
-
-                        @if ($errors->has('email'))
-                            <div class="px-3 py-2 mt-2 text-xs font-semibold bg-red-100 text-red-700 rounded-lg">{{ $errors->first('email') }}</div>
-                        @endif
-                    </label>
-                </div>
-
-                <div class="mt-3">
-                    <label>
-                        <span class="text-xs font-medium text-gray-600 {{ $errors->first('password', 'text-red-700') }}">{{ __('Password') }}</span>
-                        <input
-                            required
-                            tabindex="3"
-                            type="password"
-                            name="password"
-                            class="mt-1 form-input block w-full {{ $errors->first('password', 'border-red-500') }}"
-                            placeholder="••••••••"
-                        />
-
-                        @if ($errors->has('password'))
-                            <div class="px-3 py-2 mt-2 text-xs font-semibold bg-red-100 text-red-700 rounded-lg">{{ $errors->first('password') }}</div>
-                        @endif
-                    </label>
-                </div>
-
-                <div class="mt-3">
-                    <label>
-                        <span class="text-xs font-medium text-gray-600 {{ $errors->first('password_confirmation', 'text-red-700') }}">{{ __('Confirm Password') }}</span>
-                        <input
-                            required
-                            tabindex="4"
-                            type="password"
-                            name="password_confirmation"
-                            class="mt-1 form-input block w-full {{ $errors->first('password_confirmation', 'border-red-500') }}"
-                            placeholder="••••••••"
-                        />
-
-                        @if ($errors->has('password_confirmation'))
-                            <div class="px-3 py-2 mt-2 text-xs font-semibold bg-red-100 text-red-700 rounded-lg">{{ $errors->first('password_confirmation') }}</div>
-                        @endif
-                    </label>
-                </div>
-
-                <div class="mt-6 text-sm flex items-center justify-between">
+                <div class="space-y-4">
                     <div>
-                        {{ __('Have an account?') }}
-                        <a tabindex="6" href="{{ route('login') }}" class="font-semibold text-gray-700 hover:text-gray-800 hover:underline">{{ __('Sign in') }}</a>
+                        <label>
+                            <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('name', 'text-red-700') }}">
+                                {{ __('Name') }}
+                            </div>
+
+                            <input
+                                autofocus
+                                required
+                                tabindex="1"
+                                type="text"
+                                name="name"
+                                value="{{ old('name') }}"
+                                class="form-input block w-full {{ $errors->first('name', 'border-red-500') }}"
+                                placeholder="John Doe"
+                            />
+
+                            @if ($errors->has('name'))
+                                <div class="px-3 py-2 mt-2 text-xs font-semibold border border-red-200 bg-red-100 text-red-700 rounded-lg">
+                                    {{ $errors->first('name') }}
+                                </div>
+                            @endif
+                        </label>
                     </div>
 
-                    <button tabindex="5" class="btn px-5 py-2">{{ __('Sign up') }}</button>
+                    <div>
+                        <label>
+                            <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('email', 'text-red-700') }}">
+                                {{ __('Email') }}
+                            </div>
+
+                            <input
+                                required
+                                tabindex="2"
+                                type="email"
+                                name="email"
+                                value="{{ old('email') }}"
+                                class="form-input block w-full {{ $errors->first('email', 'border-red-500') }}"
+                                placeholder="you@example.com"
+                            />
+
+                            @if ($errors->has('email'))
+                                <div class="px-3 py-2 mt-2 text-xs font-semibold border border-red-200 bg-red-100 text-red-700 rounded-lg">
+                                    {{ $errors->first('email') }}
+                                </div>
+                            @endif
+                        </label>
+                    </div>
+
+                    <div>
+                        <label>
+                            <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('password', 'text-red-700') }}">
+                                {{ __('Password') }}
+                            </div>
+
+                            <input
+                                required
+                                tabindex="3"
+                                type="password"
+                                name="password"
+                                class="form-input block w-full {{ $errors->first('password', 'border-red-500') }}"
+                                placeholder="••••••••"
+                            />
+
+                            @if ($errors->has('password'))
+                                <div class="px-3 py-2 mt-2 text-xs font-semibold border border-red-200 bg-red-100 text-red-700 rounded-lg">
+                                    {{ $errors->first('password') }}
+                                </div>
+                            @endif
+                        </label>
+                    </div>
+
+                    <div>
+                        <label>
+                            <div class="mb-1 text-xs font-medium text-gray-600 {{ $errors->first('password_confirmation', 'text-red-700') }}">
+                                {{ __('Confirm Password') }}
+                            </div>
+
+                            <input
+                                required
+                                tabindex="4"
+                                type="password"
+                                name="password_confirmation"
+                                class="form-input block w-full {{ $errors->first('password_confirmation', 'border-red-500') }}"
+                                placeholder="••••••••"
+                            />
+
+                            @if ($errors->has('password_confirmation'))
+                                <div class="px-3 py-2 mt-2 text-xs font-semibold border border-red-200 bg-red-100 text-red-700 rounded-lg">
+                                    {{ $errors->first('password_confirmation') }}
+                                </div>
+                            @endif
+                        </label>
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-between">
+                    <div class="text-sm">
+                        {{ __('Have an account?') }}
+
+                        <a tabindex="6" href="{{ route('login') }}" class="font-semibold text-gray-700 hover:text-gray-800 hover:underline">
+                            {{ __('Sign in') }}
+                        </a>
+                    </div>
+
+                    <button tabindex="5" class="btn px-5 py-2 text-sm">
+                        {{ __('Sign up') }}
+                    </button>
                 </div>
             </form>
         </div>

--- a/src/stubs/views/auth/auth/verify.stub
+++ b/src/stubs/views/auth/auth/verify.stub
@@ -25,7 +25,8 @@
 
                 <div>
                     {{ __('Didn\'t get the email?') }}
-                    <a href="{{ route('verification.resend') }}" class="font-semibold text-brand-600 hover:text-brand-800">{{ __('Resend it') }}</a>
+                    <form action="{{ route('verification.resend') }}" method="POST" id="resendForm" class="hidden">@csrf</form>
+                    <a href="#" onclick="document.querySelector('#resendForm').submit()" class="font-semibold text-brand-600 hover:text-brand-800">{{ __('Resend it') }}</a>
                 </div>
             </div>
         </div>

--- a/src/stubs/views/auth/auth/verify.stub
+++ b/src/stubs/views/auth/auth/verify.stub
@@ -5,12 +5,14 @@
 
 @section('content-full')
     <div class="h-full flex">
-        <div class="p-6 m-auto max-w-xs w-full">
+        <div class="p-6 m-auto space-y-6 max-w-xs w-full">
             <div class="flex items-center justify-center">
-                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">{{ config('app.name') }}</a>
+                <a href="/" class="font-semibold text-gray-700 hover:text-gray-900 no-underline">
+                    {{ config('app.name') }}
+                </a>
             </div>
 
-            <div class="mt-6 mx-auto max-w-xs text-center">
+            <div class="space-y-6 mx-auto text-center">
                 <div class="text-gray-600">
                     @if (session('resent'))
                         {{ __('We have sent you a fresh verification link, please check your email.') }}
@@ -19,7 +21,7 @@
                     @endif
                 </div>
 
-                <div class="my-6 mx-auto w-16 h-px block bg-gray-400"></div>
+                <div class="mx-auto w-16 h-px block bg-gray-400"></div>
 
                 <div>
                     {{ __('Didn\'t get the email?') }}

--- a/src/stubs/views/auth/errors/404.stub
+++ b/src/stubs/views/auth/errors/404.stub
@@ -6,10 +6,10 @@
 @section('content-full')
     <div class="h-full flex">
         <div class="p-6 m-auto max-w-xs w-full">
-            <div class="mx-auto max-w-xs text-center">
+            <div class="mx-auto space-y-6 max-w-xs text-center">
                 <div class="font-semibold leading-none text-gray-800 text-5xl">404</div>
 
-                <div class="my-6 text-lg text-gray-600">{{ __('Page not found') }}</div>
+                <div class="text-lg text-gray-600">{{ __('Page not found') }}</div>
 
                 <div>
                     <a class="text-brand-600 hover:text-brand-800 no-underline" href="{{ route('home') }}">

--- a/src/stubs/views/auth/errors/419.stub
+++ b/src/stubs/views/auth/errors/419.stub
@@ -6,10 +6,10 @@
 @section('content-full')
     <div class="h-full flex">
         <div class="p-6 m-auto max-w-xs w-full">
-            <div class="mx-auto max-w-xs text-center">
+            <div class="mx-auto space-y-6 max-w-xs text-center">
                 <div class="font-semibold leading-none text-gray-800 text-5xl">419</div>
 
-                <div class="my-6 text-lg text-gray-600">{{ __('Page expired (Try refreshing)') }}</div>
+                <div class="text-lg text-gray-600">{{ __('Page expired (Try refreshing)') }}</div>
 
                 <div>
                     <a class="text-brand-600 hover:text-brand-800 no-underline" href="{{ route('home') }}">

--- a/src/stubs/views/auth/errors/500.stub
+++ b/src/stubs/views/auth/errors/500.stub
@@ -6,10 +6,10 @@
 @section('content-full')
     <div class="h-full flex">
         <div class="p-6 m-auto max-w-xs w-full">
-            <div class="mx-auto max-w-xs text-center">
+            <div class="mx-auto space-y-6 max-w-xs text-center">
                 <div class="font-semibold leading-none text-gray-800 text-5xl">500</div>
 
-                <div class="my-6 text-lg text-gray-600">{{ __('Something went wrong') }}</div>
+                <div class="text-lg text-gray-600">{{ __('Something went wrong') }}</div>
 
                 <div>
                     <a class="text-brand-600 hover:text-brand-800 no-underline" href="{{ route('home') }}">

--- a/src/stubs/views/auth/errors/503.stub
+++ b/src/stubs/views/auth/errors/503.stub
@@ -7,7 +7,7 @@
     <div class="h-full flex">
         <div class="p-6 m-auto max-w-xs w-full">
             <div class="mx-auto max-w-xs text-center">
-                <div class="my-6 text-lg text-gray-600">
+                <div class="text-lg text-gray-600">
                     {{ $exception->getMessage() ?: __('We\'re performing some maintenance, check back soon') }}
                 </div>
             </div>

--- a/src/stubs/views/auth/home.stub
+++ b/src/stubs/views/auth/home.stub
@@ -4,6 +4,12 @@
 @section('show-header', true)
 
 @section('content')
+    @if (session('status'))
+        <div class="mb-6 px-4 py-3 block rounded-lg text-sm border bg-gray-100 text-gray-800">
+            {{ session('status') }}
+        </div>
+    @endif
+
     <example-component title="Dashboard">
         You are signed in!
     </example-component>

--- a/src/stubs/views/auth/home.stub
+++ b/src/stubs/views/auth/home.stub
@@ -1,6 +1,6 @@
 @extends('layouts.base')
 
-@section('title', 'Home')
+@section('title', __('Home'))
 @section('show-header', true)
 
 @section('content')

--- a/src/stubs/views/auth/layouts/base.stub
+++ b/src/stubs/views/auth/layouts/base.stub
@@ -1,33 +1,34 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-full">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="csrf-token" content="{{ csrf_token() }}">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>@hasSection('title') @yield('title') &dash; {{ config('app.name') }} @else {{ config('app.name') }} @endif</title>
+    <title>@hasSection('title') @yield('title') &dash; {{ config('app.name') }} @else {{ config('app.name') }} @endif</title>
 
-        <link href="{{ mix('css/app.css') }}" rel="stylesheet">
-        <script src="{{ mix('js/app.js') }}" defer></script>
-    </head>
-    <body class="font-sans font-normal text-base tracking-normal leading-normal bg-white text-gray-700 h-full">
-        <div id="app" class="h-full" v-cloak>
-            @hasSection('show-header')
-                @include('layouts/partials/_header')
-            @endif
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter:400,500,600">
+    <link href="{{ mix('css/app.css') }}" rel="stylesheet">
+    <script src="{{ mix('js/app.js') }}" defer></script>
+</head>
+<body class="h-full font-sans font-normal text-base tracking-normal leading-normal bg-white text-gray-700">
+    <div id="app" class="h-full" v-cloak>
+        @hasSection('show-header')
+            @include('layouts/partials/_header')
+        @endif
 
-            @hasSection('content-full')
-                @yield('content-full')
-            @endif
+        @hasSection('content-full')
+            @yield('content-full')
+        @endif
 
-            @hasSection('content')
-                <div class="p-6 w-full">
-                    <div class="max-w-2xl mx-auto">
-                        @yield('content')
-                    </div>
+        @hasSection('content')
+            <div class="p-6">
+                <div class="max-w-2xl mx-auto">
+                    @yield('content')
                 </div>
-            @endif
-        </div>
-    </body>
+            </div>
+        @endif
+    </div>
+</body>
 </html>

--- a/src/stubs/views/auth/layouts/partials/_header.stub
+++ b/src/stubs/views/auth/layouts/partials/_header.stub
@@ -3,7 +3,9 @@
 <div class="w-full bg-gray-100 border-b">
     <div class="max-w-3xl mx-auto flex flex-wrap items-center justify-between">
         <div class="m-6 sm:mr-0">
-            <a href="/" class="font-semibold text-gray-600 hover:text-gray-800 no-underline">{{ config('app.name') }}</a>
+            <a href="/" class="font-semibold text-gray-600 hover:text-gray-800 no-underline">
+                {{ config('app.name') }}
+            </a>
         </div>
 
         <div class="m-3 block sm:hidden">
@@ -29,7 +31,11 @@
         >
             <nav class="sm:flex-1" aria-label="Left navigation">
                 <ul class="sm:flex sm:items-baseline">
-                    <li><a href="{{ route('home') }}" class="px-6 py-3 sm:p-0 sm:ml-5 block sm:inline-block text-brand-600 hover:text-brand-900 hover:bg-gray-200 sm:hover:bg-transparent no-underline">{{ __('Home') }}</a></li>
+                    <li>
+                        <a href="{{ route('home') }}" class="px-6 py-3 sm:p-0 sm:ml-5 block sm:inline-block text-brand-600 hover:text-brand-900 hover:bg-gray-200 sm:hover:bg-transparent no-underline">
+                            {{ __('Home') }}
+                        </a>
+                    </li>
                 </ul>
             </nav>
 
@@ -37,16 +43,27 @@
                 <ul class="sm:flex sm:items-baseline">
                     @auth
                         <li>
+                            <form action="{{ route('logout') }}" method="POST" id="logoutForm" class="hidden">@csrf</form>
                             <a
                                 href="#"
                                 class="px-6 py-3 sm:p-0 sm:ml-5 block sm:inline-block text-brand-600 hover:text-brand-900 hover:bg-gray-200 sm:hover:bg-transparent no-underline"
                                 onclick="document.querySelector('#logoutForm').submit()"
-                            >{{ __('Logout') }}</a>
-                            <form action="{{ route('logout') }}" method="POST" id="logoutForm" class="hidden">@csrf</form>
+                            >
+                                {{ __('Logout') }}
+                            </a>
                         </li>
                     @else
-                        <li><a href="{{ route('login') }}" class="px-6 py-3 sm:p-0 sm:ml-5 block sm:inline-block text-brand-600 hover:text-brand-900 hover:bg-gray-200 sm:hover:bg-transparent no-underline">{{ __('Sign in') }}</a></li>
-                        <li><a href="{{ route('register') }}" class="px-6 py-3 sm:p-0 sm:ml-5 block sm:inline-block text-brand-600 hover:text-brand-900 hover:bg-gray-200 sm:hover:bg-transparent no-underline">{{ __('Sign up') }}</a></li>
+                        <li>
+                            <a href="{{ route('login') }}" class="px-6 py-3 sm:p-0 sm:ml-5 block sm:inline-block text-brand-600 hover:text-brand-900 hover:bg-gray-200 sm:hover:bg-transparent no-underline">
+                                {{ __('Sign in') }}
+                            </a>
+                        </li>
+
+                        <li>
+                            <a href="{{ route('register') }}" class="px-6 py-3 sm:p-0 sm:ml-5 block sm:inline-block text-brand-600 hover:text-brand-900 hover:bg-gray-200 sm:hover:bg-transparent no-underline">
+                                {{ __('Sign up') }}
+                            </a>
+                        </li>
                     @endauth
                 </ul>
             </nav>

--- a/src/stubs/views/auth/welcome.stub
+++ b/src/stubs/views/auth/welcome.stub
@@ -4,23 +4,17 @@
 @section('show-header', false)
 
 @section('content-full')
-    <div class="h-full flex relative">
+    <div class="h-screen flex">
         @if (Route::has('login'))
             <div class="m-8 absolute top-0 right-0">
-                <ul class="-mr-6 flex items-baseline font-semibold text-brand-600">
+                <ul class="space-x-6 flex items-baseline font-semibold text-brand-600">
                     @auth
-                        <li class="mr-6">
-                            <a class="hover:text-brand-800" href="{{ route('home') }}">{{ __('Home') }}</a>
-                        </li>
+                        <li><a class="hover:text-brand-800" href="{{ route('home') }}">{{ __('Home') }}</a></li>
                     @else
-                        <li class="mr-6">
-                            <a class="hover:text-brand-800" href="{{ route('login') }}">{{ __('Sign in') }}</a>
-                        </li>
+                        <li><a class="hover:text-brand-800" href="{{ route('login') }}">{{ __('Sign in') }}</a></li>
 
                         @if (Route::has('register'))
-                            <li class="mr-6">
-                                <a class="hover:text-brand-800" href="{{ route('register') }}">{{ __('Sign up') }}</a>
-                            </li>
+                            <li><a class="hover:text-brand-800" href="{{ route('register') }}">{{ __('Sign up') }}</a></li>
                         @endif
                     @endauth
                 </ul>
@@ -30,34 +24,14 @@
         <div class="p-6 m-auto text-center font-semibold">
             <h1 class="leading-tight text-4xl text-gray-700">{{ config('app.name') }}</h1>
 
-            <ul class="-mb-4 sm:-mr-6 mt-8 block sm:flex items-baseline text-brand-600">
-                <li class="mb-4 sm:mr-6">
-                    <a class="hover:text-brand-800" href="https://laravel.com/docs">Docs</a>
-                </li>
-
-                <li class="mb-4 sm:mr-6">
-                    <a class="hover:text-brand-800" href="https://laracasts.com">Laracasts</a>
-                </li>
-
-                <li class="mb-4 sm:mr-6">
-                    <a class="hover:text-brand-800" href="https://laravel-news.com">News</a>
-                </li>
-
-                <li class="mb-4 sm:mr-6">
-                    <a class="hover:text-brand-800" href="https://blog.laravel.com">Blog</a>
-                </li>
-
-                <li class="mb-4 sm:mr-6">
-                    <a class="hover:text-brand-800" href="https://nova.laravel.com">Nova</a>
-                </li>
-
-                <li class="mb-4 sm:mr-6">
-                    <a class="hover:text-brand-800" href="https://forge.laravel.com">Forge</a>
-                </li>
-
-                <li class="mb-4 sm:mr-6">
-                    <a class="hover:text-brand-800" href="https://github.com/laravel/laravel">GitHub</a>
-                </li>
+            <ul class="mt-8 space-y-3 sm:space-y-0 sm:space-x-6 block sm:flex items-baseline text-brand-600">
+                <li><a class="hover:text-brand-800" href="https://laravel.com/docs">Docs</a></li>
+                <li><a class="hover:text-brand-800" href="https://laracasts.com">Laracasts</a></li>
+                <li><a class="hover:text-brand-800" href="https://laravel-news.com">News</a></li>
+                <li><a class="hover:text-brand-800" href="https://blog.laravel.com">Blog</a></li>
+                <li><a class="hover:text-brand-800" href="https://nova.laravel.com">Nova</a></li>
+                <li><a class="hover:text-brand-800" href="https://forge.laravel.com">Forge</a></li>
+                <li><a class="hover:text-brand-800" href="https://github.com/laravel/laravel">GitHub</a></li>
             </ul>
         </div>
     </div>

--- a/src/stubs/views/default/welcome.stub
+++ b/src/stubs/views/default/welcome.stub
@@ -1,51 +1,34 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-full">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="csrf-token" content="{{ csrf_token() }}">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name') }}</title>
+    <title>Welcome &dash; {{ config('app.name') }}</title>
 
-        <link href="{{ mix('css/app.css') }}" rel="stylesheet">
-        <script src="{{ mix('js/app.js') }}" defer></script>
-    </head>
-    <body class="font-sans font-normal text-base tracking-normal leading-normal bg-white text-gray-700 h-full">
-        <div id="app" class="h-full flex" v-cloak>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter:400,500,600">
+    <link href="{{ mix('css/app.css') }}" rel="stylesheet">
+    <script src="{{ mix('js/app.js') }}" defer></script>
+</head>
+<body class="h-full font-sans font-normal text-base tracking-normal leading-normal bg-white text-gray-700">
+    <div id="app" class="h-full" v-cloak>
+        <div class="h-screen flex">
             <div class="p-6 m-auto text-center font-semibold">
                 <h1 class="leading-tight text-4xl text-gray-700">{{ config('app.name') }}</h1>
 
-                <ul class="-mb-4 sm:-mr-6 mt-8 block sm:flex items-baseline text-brand-600">
-                    <li class="mb-4 sm:mr-6">
-                        <a class="hover:text-brand-800" href="https://laravel.com/docs">Docs</a>
-                    </li>
-
-                    <li class="mb-4 sm:mr-6">
-                        <a class="hover:text-brand-800" href="https://laracasts.com">Laracasts</a>
-                    </li>
-
-                    <li class="mb-4 sm:mr-6">
-                        <a class="hover:text-brand-800" href="https://laravel-news.com">News</a>
-                    </li>
-
-                    <li class="mb-4 sm:mr-6">
-                        <a class="hover:text-brand-800" href="https://blog.laravel.com">Blog</a>
-                    </li>
-
-                    <li class="mb-4 sm:mr-6">
-                        <a class="hover:text-brand-800" href="https://nova.laravel.com">Nova</a>
-                    </li>
-
-                    <li class="mb-4 sm:mr-6">
-                        <a class="hover:text-brand-800" href="https://forge.laravel.com">Forge</a>
-                    </li>
-
-                    <li class="mb-4 sm:mr-6">
-                        <a class="hover:text-brand-800" href="https://github.com/laravel/laravel">GitHub</a>
-                    </li>
+                <ul class="mt-8 space-y-3 sm:space-y-0 sm:space-x-6 block sm:flex items-baseline text-brand-600">
+                    <li><a class="hover:text-brand-800" href="https://laravel.com/docs">Docs</a></li>
+                    <li><a class="hover:text-brand-800" href="https://laracasts.com">Laracasts</a></li>
+                    <li><a class="hover:text-brand-800" href="https://laravel-news.com">News</a></li>
+                    <li><a class="hover:text-brand-800" href="https://blog.laravel.com">Blog</a></li>
+                    <li><a class="hover:text-brand-800" href="https://nova.laravel.com">Nova</a></li>
+                    <li><a class="hover:text-brand-800" href="https://forge.laravel.com">Forge</a></li>
+                    <li><a class="hover:text-brand-800" href="https://github.com/laravel/laravel">GitHub</a></li>
                 </ul>
             </div>
         </div>
-    </body>
+    </div>
+</body>
 </html>

--- a/src/stubs/webpack.stub
+++ b/src/stubs/webpack.stub
@@ -1,12 +1,12 @@
 const mix = require('laravel-mix')
 
 mix.setPublicPath('public')
-  .js('resources/js/app.js', 'public/js')
-  .postCss('resources/css/tailwind.css', 'public/css/app.css', [
-    require('tailwindcss'),
-    require('autoprefixer'),
-  ])
+    .js('resources/js/app.js', 'public/js')
+    .postCss('resources/css/tailwind.css', 'public/css/app.css', [
+        require('tailwindcss'),
+        require('autoprefixer'),
+    ])
 
 if (mix.inProduction()) {
-  mix.version()
+    mix.version()
 }

--- a/src/stubs/webpack.stub
+++ b/src/stubs/webpack.stub
@@ -1,14 +1,12 @@
-require('laravel-mix-purgecss')
-
 const mix = require('laravel-mix')
 
 mix.setPublicPath('public')
+  .js('resources/js/app.js', 'public/js')
   .postCss('resources/css/tailwind.css', 'public/css/app.css', [
     require('tailwindcss'),
     require('autoprefixer'),
   ])
-  .js('resources/js/app.js', 'public/js')
 
 if (mix.inProduction()) {
-  mix.purgeCss().version()
+  mix.version()
 }


### PR DESCRIPTION
This PR adds support for Laravel 7, which removed the ability to create presets. This means this package now depends on `laravel/ui` for the base preset system, which allows for more consistency.

Tailwind is now updated to 1.4, which includes PurgeCSS by default. This slims the Laravel Mix configuration file, and adds a `purge` section to the Tailwind configuration file.